### PR TITLE
fix: proxy failing to start with aiohttp 3.10

### DIFF
--- a/app/asyncrequest.py
+++ b/app/asyncrequest.py
@@ -126,7 +126,7 @@ class AsyncRequest(QtCore.QObject):
             self._teardown() # Making a new request cancels any in progress request
 
             self._requestTask = asyncio.ensure_future(
-                self._getRequestAsync(url),
+                self._getRequestAsync(url=url, loop=loop),
                 loop=loop)
 
             if timeout != None:
@@ -148,7 +148,7 @@ class AsyncRequest(QtCore.QObject):
             self._teardown() # Making a new request cancels any in progress request
 
             self._requestTask = asyncio.ensure_future(
-                self._postRequestAsync(url=url, content=content, headers=headers),
+                self._postRequestAsync(url=url, content=content, headers=headers, loop=loop),
                 loop=loop)
 
             if timeout != None:
@@ -160,12 +160,13 @@ class AsyncRequest(QtCore.QObject):
 
     async def _getRequestAsync(
             self,
-            url: str
+            url: str,
+            loop: typing.Optional[asyncio.AbstractEventLoop] = None # None means use current loop
             ) -> None:
         try:
             logging.info(f'Starting async GET request for {url}')
 
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(loop=loop) as session:
                 async with session.get(url=url) as response:
                     status = response.status
                     reason = response.reason
@@ -196,7 +197,8 @@ class AsyncRequest(QtCore.QObject):
             self,
             url: str,
             content: typing.Optional[typing.Union[bytes, str, typing.Mapping[str, typing.Union[bytes, str]]]],
-            headers: typing.Optional[typing.Mapping[str, str]]
+            headers: typing.Optional[typing.Mapping[str, str]],
+            loop: typing.Optional[asyncio.AbstractEventLoop] = None # None means use current loop
             ) -> None:
         try:
             logging.debug(f'Starting async POST request to {url}')
@@ -215,7 +217,7 @@ class AsyncRequest(QtCore.QObject):
             else:
                 data = content
 
-            async with aiohttp.ClientSession(headers=headers) as session:
+            async with aiohttp.ClientSession(headers=headers, loop=loop) as session:
                 async with session.post(url=url, data=data) as response:
                     status = response.status
                     reason = response.reason

--- a/proxy/mapproxy.py
+++ b/proxy/mapproxy.py
@@ -326,7 +326,8 @@ class MapProxy(object):
                 travellerMapUrl=travellerMapUrl,
                 installDir=installDir,
                 tileCache=tileCache,
-                compositor=compositor)
+                compositor=compositor,
+                loop=loop)
             loop.run_until_complete(requestHandler.initAsync())
             if mainsData:
                 # Add static route for mains data
@@ -337,7 +338,8 @@ class MapProxy(object):
 
             # Set up web server with all requests redirected to my handler
             webApp = aiohttp.web.Application(
-                middlewares=[_serverHeaderMiddlewareAsync])
+                middlewares=[_serverHeaderMiddlewareAsync],
+                loop=loop)
             webApp.router.add_route(
                 method='*',
                 path='/{path:.*?}',

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,7 @@ darkdetect>=0.7.1
 reportlab>=3.6.12
 Pillow>=9.5.0
 aiofiles>=23.2.1
-# BUG: Something has changed in aiohttp 3.10 that means the proxy fails to
-# start. I've temporarily limited the version number while I work on a fix.
-aiohttp>=3.8.6,<=3.9.5
+aiohttp>=3.8.6
 aiosqlite>=0.19.0
 qasync>=0.26.0
 xmlschema>=2.5.0


### PR DESCRIPTION
Proxy was failing to start with the error below when using aiohttp 3.10. 

```
Traceback (most recent call last):
  File "E:\Projects\autojimmy\proxy\mapproxy.py", line 325, in _serviceCallback
    requestHandler = proxy.RequestHandler(
                     ^^^^^^^^^^^^^^^^^^^^^
  File "E:\Projects\autojimmy\proxy\requesthandler.py", line 102, in __init__
    self._connector = aiohttp.TCPConnector(
                      ^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\GrooveStar\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiohttp\connector.py", line 784, in __init__
    super().__init__(
  File "C:\Users\GrooveStar\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiohttp\connector.py", line 234, in __init__
    loop = loop or asyncio.get_running_loop()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: no running event loop
An exception occurred while starting the proxy
  File "E:\Projects\autojimmy\jobs\startupjobs.py", line 33, in run
    self.executeJob()
    proxy.MapProxy.instance().start(
  File "E:\Projects\autojimmy\proxy\mapproxy.py", line 161, in start
    raise RuntimeError(f'Map proxy failed to start ({message[1]})')
RuntimeError: Map proxy failed to start (no running event loop)
```

The issue was triggered by [this aiohttp PR](https://github.com/aio-libs/aiohttp/pull/8512) which changed behaviour so that some classes must now be explicitly passed a loop at construction if there isn't one currently running.
