### PR TITLE
fix: improve license accuracy

### DIFF
--- a/licenses/Sector Data/LICENSE
+++ b/licenses/Sector Data/LICENSE
@@ -1,4 +1,4 @@
-Auto-Jimmy includes an unmodified snapshot of sector data taken from travellermap.com.
+Auto-Jimmy includes a snapshot of sector data taken from travellermap.com.
 These data files are Copyright their original authors, noted where possible.
 
 More accreditation information can be found here https://travellermap.com/doc/credits


### PR DESCRIPTION
Removed unmodified as I do rename some sectors to disambiguate their names